### PR TITLE
Convert colons in parameters to underscores by default when generating C# clients

### DIFF
--- a/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
@@ -32,6 +32,7 @@ namespace NSwag.CodeGeneration
             var variableName = ConversionUtilities.ConvertToLowerCamelCase(name
                 .Replace("-", "_")
                 .Replace(".", "_")
+                .Replace(":", "_")
                 .Replace("$", string.Empty)
                 .Replace("@", string.Empty)
                 .Replace("[", string.Empty)


### PR DESCRIPTION
Based on result of #4221 .

Doesn't include tests, but I can't find tests for the specific function changed to add them to. I'd be happy to add them if someone wants to point me in the right direction.

Fixes #4188 (I think)